### PR TITLE
Fix tz warning for timestamps in UTC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ test = [
   "respx",
 ]
 
-
 [tool.mypy]
 exclude="tests"
 

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -144,7 +144,7 @@ class EnlyzeClient:
 
         """
 
-        if not start.tzname() or not end.tzname():
+        if start.utcoffset() is None or end.utcoffset() is None:
             logging.warning(
                 "Passing naive datetime is discouraged, assuming local timezone."
             )

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -144,7 +144,7 @@ class EnlyzeClient:
 
         """
 
-        if not start.utcoffset() or not end.utcoffset():
+        if not start.tzname() or not end.tzname():
             logging.warning(
                 "Passing naive datetime is discouraged, assuming local timezone."
             )


### PR DESCRIPTION
**Summary**
Fixing the use of `utcoffset()` to determine if a timestamp is timezone naive or not.

**Problem Description**
When using the `get_timeseries()` method with timestamps in UTC, the warning "Passing naive datetime is discouraged, assuming local timezone." is shown even though the timestamps have timezone information.

![Bildschirmfoto 2023-03-07 um 16 50 08](https://user-images.githubusercontent.com/33221251/223475068-de821268-a8b2-4772-be6a-9047cf174095.png)

**Solution**
This is because for timestamps in UTC `not time.utcoffset()` evaluates to True. We must check if it's `None` instead.