### PR TITLE
Don't constrain querying timeseries data in future.

### DIFF
--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -131,9 +131,8 @@ class EnlyzeClient:
         system where the code is run.
 
         :param start: Beginning of the time frame for which to fetch timeseries data.
-            Must not be in the future and must be before ``end``.
-        :param end: End of the time frame for which to fetch timeseries data. Must not
-            be in the future.
+            Must not be before ``end``.
+        :param end: End of the time frame for which to fetch timeseries data.
         :param variables: The variables for which to fetch timeseries data.
 
         :raises: |token-error|
@@ -151,9 +150,6 @@ class EnlyzeClient:
 
         start = _ensure_datetime_aware(start)
         end = _ensure_datetime_aware(end)
-
-        if end > datetime.now(tz=timezone.utc):
-            raise EnlyzeError("Cannot request timeseries data in the future")
 
         if start > end:
             raise EnlyzeError("Start must be earlier than end")

--- a/tests/enlyze/test_client.py
+++ b/tests/enlyze/test_client.py
@@ -199,11 +199,6 @@ def test_get_timeseries_raises_no_variables():
 def test_get_timeseries_raises_invalid_time_bounds(variable):
     client = make_client()
 
-    with pytest.raises(EnlyzeError, match="data in the future"):
-        client.get_timeseries(
-            datetime.now(), datetime.now() + timedelta(days=1), [variable]
-        )
-
     with pytest.raises(EnlyzeError, match="Start must be earlier than end"):
         client.get_timeseries(
             datetime.now() + timedelta(days=1), datetime.now(), [variable]


### PR DESCRIPTION
Clocks may not be accurately synchronized all the time, so slight variations can already make query fail. However, there are no negative consequences from querying data int the future (except maybe to catch a usage error) so don't deny it anymore.