### PR TITLE
Fix `ProductionRun.appliance` docstring

### DIFF
--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -250,7 +250,7 @@ class ProductionRun:
     #: The UUID of the production run
     uuid: UUID
 
-    #: The UUID of the appliance the production run was executed on.
+    #: The appliance the production run was executed on.
     appliance: Appliance
 
     #: The average throughput of the production run excluding downtimes.


### PR DESCRIPTION
Currently, the `ProductionRun` model's `appliance` member is documented as the appliance `UUID`, while it is actually an `Appliance` model. This PR fixes this.