### PR TITLE
Fix quantity unit of production run may be None.

### DIFF
--- a/src/enlyze/api_clients/production_runs/models.py
+++ b/src/enlyze/api_clients/production_runs/models.py
@@ -47,7 +47,7 @@ class Product(ProductionRunsApiModel):
 
 
 class Quantity(ProductionRunsApiModel):
-    unit: str
+    unit: str | None
     value: float
 
     def to_user_model(self) -> user_models.Quantity:

--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -222,7 +222,7 @@ class Quantity:
     """Representation of a physical quantity"""
 
     #: Physical unit of quantity
-    unit: str
+    unit: str | None
 
     #: The quantity expressed in `unit`
     value: float


### PR DESCRIPTION
We recently made quantity units of production runs optional in the upstream service, so we have to make the same change here as well.