### PR TITLE
Change service URLs to new /api/* subpath.

### DIFF
--- a/src/enlyze/constants.py
+++ b/src/enlyze/constants.py
@@ -2,10 +2,10 @@
 ENLYZE_BASE_URL = "https://app.enlyze.com"
 
 #: URL sub-path where the Timeseries API is deployed on the ENLYZE platform.
-TIMESERIES_API_SUB_PATH = "timeseries-service/v1/"
+TIMESERIES_API_SUB_PATH = "api/timeseries/v1/"
 
 #: URL sub-path where the Production Runs API is deployed on the ENLYZE platform.
-PRODUCTION_RUNS_API_SUB_PATH = "production-runs/v1/"
+PRODUCTION_RUNS_API_SUB_PATH = "api/production-runs/v1/"
 
 #: HTTP timeout for requests to the Timeseries API.
 #:


### PR DESCRIPTION
We now concentrate our public service APIs under `/api/*`, so adapt the URLs here accordingly.