### PR TITLE
Allow setting base URL when constructing EnlyzeClient.

### DIFF
--- a/src/enlyze/api_clients/base.py
+++ b/src/enlyze/api_clients/base.py
@@ -9,7 +9,7 @@ import httpx
 from pydantic import BaseModel, ValidationError
 
 from enlyze.auth import TokenAuth
-from enlyze.constants import ENLYZE_BASE_URL, HTTPX_TIMEOUT
+from enlyze.constants import HTTPX_TIMEOUT
 from enlyze.errors import EnlyzeError, InvalidTokenError
 
 

--- a/src/enlyze/api_clients/base.py
+++ b/src/enlyze/api_clients/base.py
@@ -51,9 +51,9 @@ class ApiBaseClient(ABC, Generic[R]):
 
     def __init__(
         self,
-        token: str,
         *,
-        base_url: str | httpx.URL = ENLYZE_BASE_URL,
+        token: str,
+        base_url: str | httpx.URL,
         timeout: float = HTTPX_TIMEOUT,
     ):
         self._client = httpx.Client(

--- a/src/enlyze/api_clients/production_runs/client.py
+++ b/src/enlyze/api_clients/production_runs/client.py
@@ -4,7 +4,7 @@ import httpx
 from pydantic import BaseModel
 
 from enlyze.api_clients.base import ApiBaseClient, PaginatedResponseBaseModel
-from enlyze.constants import ENLYZE_BASE_URL, PRODUCTION_RUNS_API_SUB_PATH
+from enlyze.constants import PRODUCTION_RUNS_API_SUB_PATH
 
 
 class _Metadata(BaseModel):

--- a/src/enlyze/api_clients/production_runs/client.py
+++ b/src/enlyze/api_clients/production_runs/client.py
@@ -29,10 +29,14 @@ class ProductionRunsApiClient(ApiBaseClient[_PaginatedResponse]):
     PaginatedResponseModel = _PaginatedResponse
 
     def __init__(
-        self, token: str, *, base_url: str | httpx.URL = ENLYZE_BASE_URL, **kwargs: Any
+        self,
+        *,
+        token: str,
+        base_url: str | httpx.URL,
+        **kwargs: Any,
     ):
         super().__init__(
-            token,
+            token=token,
             base_url=httpx.URL(base_url).join(PRODUCTION_RUNS_API_SUB_PATH),
             **kwargs,
         )

--- a/src/enlyze/api_clients/timeseries/client.py
+++ b/src/enlyze/api_clients/timeseries/client.py
@@ -25,13 +25,15 @@ class TimeseriesApiClient(ApiBaseClient[_PaginatedResponse]):
 
     def __init__(
         self,
-        token: str,
         *,
-        base_url: str | httpx.URL = ENLYZE_BASE_URL,
+        token: str,
+        base_url: str | httpx.URL,
         **kwargs: Any,
     ):
         super().__init__(
-            token, base_url=httpx.URL(base_url).join(TIMESERIES_API_SUB_PATH), **kwargs
+            token=token,
+            base_url=httpx.URL(base_url).join(TIMESERIES_API_SUB_PATH),
+            **kwargs,
         )
 
     def _transform_paginated_response_data(

--- a/src/enlyze/api_clients/timeseries/client.py
+++ b/src/enlyze/api_clients/timeseries/client.py
@@ -4,7 +4,7 @@ import httpx
 from pydantic import AnyUrl
 
 from enlyze.api_clients.base import ApiBaseClient, PaginatedResponseBaseModel
-from enlyze.constants import ENLYZE_BASE_URL, TIMESERIES_API_SUB_PATH
+from enlyze.constants import TIMESERIES_API_SUB_PATH
 
 
 class _PaginatedResponse(PaginatedResponseBaseModel):

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -52,14 +52,14 @@ class EnlyzeClient:
 
     """
 
-    def __init__(self, token: str, base_url: str | None = ENLYZE_BASE_URL) -> None:
+    def __init__(self, token: str, base_url: str | None = None) -> None:
         self._timeseries_api_client = TimeseriesApiClient(
             token=token,
-            base_url=base_url,
+            base_url=base_url or ENLYZE_BASE_URL,
         )
         self._production_runs_api_client = ProductionRunsApiClient(
             token=token,
-            base_url=base_url,
+            base_url=base_url or ENLYZE_BASE_URL,
         )
 
     def _get_sites(self) -> Iterator[timeseries_api_models.Site]:

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -52,14 +52,14 @@ class EnlyzeClient:
 
     """
 
-    def __init__(self, token: str, base_url: str | None = None) -> None:
+    def __init__(self, token: str, *, _base_url: str | None = None) -> None:
         self._timeseries_api_client = TimeseriesApiClient(
             token=token,
-            base_url=base_url or ENLYZE_BASE_URL,
+            base_url=_base_url or ENLYZE_BASE_URL,
         )
         self._production_runs_api_client = ProductionRunsApiClient(
             token=token,
-            base_url=base_url or ENLYZE_BASE_URL,
+            base_url=_base_url or ENLYZE_BASE_URL,
         )
 
     def _get_sites(self) -> Iterator[timeseries_api_models.Site]:

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -8,7 +8,10 @@ import enlyze.models as user_models
 from enlyze.api_clients.production_runs.client import ProductionRunsApiClient
 from enlyze.api_clients.production_runs.models import ProductionRun
 from enlyze.api_clients.timeseries.client import TimeseriesApiClient
-from enlyze.constants import VARIABLE_UUID_AND_RESAMPLING_METHOD_SEPARATOR
+from enlyze.constants import (
+    ENLYZE_BASE_URL,
+    VARIABLE_UUID_AND_RESAMPLING_METHOD_SEPARATOR,
+)
 from enlyze.errors import EnlyzeError
 from enlyze.validators import (
     validate_datetime,
@@ -49,9 +52,15 @@ class EnlyzeClient:
 
     """
 
-    def __init__(self, token: str) -> None:
-        self._timeseries_api_client = TimeseriesApiClient(token=token)
-        self._production_runs_api_client = ProductionRunsApiClient(token=token)
+    def __init__(self, token: str, base_url: str | None = ENLYZE_BASE_URL) -> None:
+        self._timeseries_api_client = TimeseriesApiClient(
+            token=token,
+            base_url=base_url,
+        )
+        self._production_runs_api_client = ProductionRunsApiClient(
+            token=token,
+            base_url=base_url,
+        )
 
     def _get_sites(self) -> Iterator[timeseries_api_models.Site]:
         """Get all sites from the API"""

--- a/tests/enlyze/api_clients/conftest.py
+++ b/tests/enlyze/api_clients/conftest.py
@@ -17,3 +17,8 @@ def string_model():
 @pytest.fixture
 def endpoint():
     return "https://my-endpoint.com"
+
+
+@pytest.fixture
+def base_url():
+    return "http://api-client-base"

--- a/tests/enlyze/api_clients/production_runs/test_client.py
+++ b/tests/enlyze/api_clients/production_runs/test_client.py
@@ -36,11 +36,6 @@ def paginated_response_with_next_page(response_data, metadata_next_page):
 
 
 @pytest.fixture
-def base_url():
-    return "http://x"
-
-
-@pytest.fixture
 def production_runs_client(auth_token, base_url):
     return ProductionRunsApiClient(token=auth_token, base_url=base_url)
 

--- a/tests/enlyze/api_clients/production_runs/test_client.py
+++ b/tests/enlyze/api_clients/production_runs/test_client.py
@@ -36,12 +36,16 @@ def paginated_response_with_next_page(response_data, metadata_next_page):
 
 
 @pytest.fixture
-def production_runs_client(auth_token):
-    return ProductionRunsApiClient(token=auth_token)
+def base_url():
+    return "http://x"
 
 
-def test_timeseries_api_appends_sub_path(auth_token):
-    base_url = ENLYZE_BASE_URL
+@pytest.fixture
+def production_runs_client(auth_token, base_url):
+    return ProductionRunsApiClient(token=auth_token, base_url=base_url)
+
+
+def test_timeseries_api_appends_sub_path(auth_token, base_url):
     expected = str(httpx.URL(base_url).join(PRODUCTION_RUNS_API_SUB_PATH))
     client = ProductionRunsApiClient(token=auth_token, base_url=base_url)
     assert client._full_url("") == expected

--- a/tests/enlyze/api_clients/production_runs/test_client.py
+++ b/tests/enlyze/api_clients/production_runs/test_client.py
@@ -7,7 +7,7 @@ from enlyze.api_clients.production_runs.client import (
     _Metadata,
     _PaginatedResponse,
 )
-from enlyze.constants import ENLYZE_BASE_URL, PRODUCTION_RUNS_API_SUB_PATH
+from enlyze.constants import PRODUCTION_RUNS_API_SUB_PATH
 
 
 @pytest.fixture

--- a/tests/enlyze/api_clients/test_base.py
+++ b/tests/enlyze/api_clients/test_base.py
@@ -12,7 +12,6 @@ from enlyze.api_clients.base import (
     ApiBaseModel,
     PaginatedResponseBaseModel,
 )
-from enlyze.constants import ENLYZE_BASE_URL
 from enlyze.errors import EnlyzeError, InvalidTokenError
 
 

--- a/tests/enlyze/api_clients/timeseries/test_client.py
+++ b/tests/enlyze/api_clients/timeseries/test_client.py
@@ -35,12 +35,16 @@ def paginated_response_with_next_page(endpoint):
 
 
 @pytest.fixture
-def timeseries_client(auth_token):
-    return TimeseriesApiClient(token=auth_token)
+def base_url():
+    return "http://x"
 
 
-def test_timeseries_api_appends_sub_path(auth_token):
-    base_url = "https://some-base-url.com"
+@pytest.fixture
+def timeseries_client(auth_token, base_url):
+    return TimeseriesApiClient(token=auth_token, base_url=base_url)
+
+
+def test_timeseries_api_appends_sub_path(auth_token, base_url):
     expected = str(httpx.URL(base_url).join(TIMESERIES_API_SUB_PATH))
     client = TimeseriesApiClient(token=auth_token, base_url=base_url)
     assert client._full_url("") == expected

--- a/tests/enlyze/api_clients/timeseries/test_client.py
+++ b/tests/enlyze/api_clients/timeseries/test_client.py
@@ -35,11 +35,6 @@ def paginated_response_with_next_page(endpoint):
 
 
 @pytest.fixture
-def base_url():
-    return "http://x"
-
-
-@pytest.fixture
 def timeseries_client(auth_token, base_url):
     return TimeseriesApiClient(token=auth_token, base_url=base_url)
 


### PR DESCRIPTION
With internal use-cases popping up, we need the ability to set a non-standard base URL for the ENLYZE platform. For our users, nothing should change as the same default will still be taken.