### PR TITLE
Enforce schema of ProductionRuns DataFrame.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,9 @@ nitpick_ignore_regex = [
     ("py:class", r".*\.T"),
     ("py:.*", r"httpx\..*"),
 ]
+nitpick_ignore = [
+    ("py:class", "ComputedFieldInfo"),
+]
 
 autodoc_default_options = {"exclude-members": "__weakref__, __init__, __new__"}
 autodoc_member_order = "bysource"

--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -1,4 +1,5 @@
-from dataclasses import asdict, dataclass
+import typing
+from dataclasses import asdict, dataclass, is_dataclass
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from itertools import chain
@@ -6,6 +7,30 @@ from typing import Any, Iterator, Optional, Sequence
 from uuid import UUID
 
 import pandas
+
+
+def _get_optional_dataclass_fields(cls: object) -> set[str]:
+    hints = typing.get_type_hints(cls)
+    optional_fields = set()
+    for field, typ in hints.items():
+        if typing.get_origin(typ) != typing.Union:
+            continue
+
+        args = list(typing.get_args(typ))
+        try:
+            args.remove(type(None))
+        except ValueError:
+            continue
+
+        try:
+            (nested_type,) = args
+        except ValueError:
+            continue
+
+        if is_dataclass(nested_type):
+            optional_fields.add(field)
+
+    return optional_fields
 
 
 @dataclass(frozen=True)
@@ -289,9 +314,72 @@ class ProductionRun:
     #: Aggregate OEE score that comprises availability, performance and quality.
     productivity: Optional[OEEComponent]
 
+    def to_dict(self, exclude_unset_objects: bool = False) -> dict[str, Any]:
+        """Convert to Python dictionary.
+
+        The ``start`` and ``end`` fields will be represented as
+        :ref:`timezone-aware <python:datetime-naive-aware>`
+        :py:class:`datetime.datetime` localized in UTC.
+
+        :param exclude_unset_objects: Exclude fields that are typed as optional
+            dataclasses and set to ``None``.
+
+        :returns: Production run represented as Python dictionary.
+
+        """
+        data = asdict(
+            self,
+            dict_factory=lambda items: {
+                k: v
+                for k, v in items
+                if not (
+                    exclude_unset_objects
+                    and k in _get_optional_dataclass_fields(self)
+                    and v is None
+                )
+            },
+        )
+
+        data["start"] = data["start"].astimezone(timezone.utc)
+        if data["end"]:
+            data["end"] = data["end"].astimezone(timezone.utc)
+
+        return data
+
+    def to_dataframe(self) -> pandas.DataFrame:
+        """Convert to :py:class:`pandas.DataFrame`
+
+        The ``start`` and ``end`` fields will be represented as
+        :ref:`timezone-aware <python:datetime-naive-aware>`
+        :py:class:`datetime.datetime` localized in UTC.
+
+        :returns: DataFrame with a single row representing the production run.
+        """
+        return pandas.json_normalize(self.to_dict(exclude_unset_objects=True))
+
 
 class ProductionRuns(list[ProductionRun]):
     """Representation of multiple production runs."""
+
+    def to_dicts(self, exclude_unset_objects: bool = False) -> list[dict[str, Any]]:
+        """Convert to Python dictionaries.
+
+        The ``start`` and ``end`` fields will be represented as
+        :ref:`timezone-aware <python:datetime-naive-aware>`
+        :py:class:`datetime.datetime` localized in UTC.
+
+        :param exclude_unset_objects: Exclude fields that are typed as optional
+            dataclasses and set to ``None``.
+
+        :returns: List of Production runs represented as Python dictionaries.
+
+        """
+        return [
+            run.to_dict(
+                exclude_unset_objects=exclude_unset_objects,
+            )
+            for run in self
+        ]
 
     def to_dataframe(self) -> pandas.DataFrame:
         """Convert production runs into :py:class:`pandas.DataFrame`
@@ -300,13 +388,9 @@ class ProductionRuns(list[ProductionRun]):
         ``end`` of every production run will be represented as :ref:`timezone-aware
         <python:datetime-naive-aware>` :py:class:`datetime.datetime` localized in UTC.
 
-        :returns: DataFrame with production runs
-
+        :returns: DataFrame with production runs.
         """
         if not self:
             return pandas.DataFrame()
 
-        df = pandas.json_normalize([asdict(run) for run in self])
-        df.start = pandas.to_datetime(df.start, utc=True, format="ISO8601")
-        df.end = pandas.to_datetime(df.end, utc=True, format="ISO8601")
-        return df
+        return pandas.json_normalize(self.to_dicts(exclude_unset_objects=True))

--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -1,6 +1,4 @@
-import collections
-import typing
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from itertools import chain
@@ -9,88 +7,7 @@ from uuid import UUID
 
 import pandas
 
-
-def _get_optional_dataclass_fields(cls: object) -> set[str]:
-    hints = typing.get_type_hints(cls)
-    optional_fields = set()
-    for field, typ in hints.items():
-        if typing.get_origin(typ) != typing.Union:
-            continue
-
-        args = list(typing.get_args(typ))
-        try:
-            args.remove(type(None))
-        except ValueError:
-            continue
-
-        try:
-            (nested_type,) = args
-        except ValueError:
-            continue
-
-        if is_dataclass(nested_type):
-            optional_fields.add(field)
-
-    return optional_fields
-
-
-def dict_merge(dct, merge_dct):
-    dct = dct.copy()
-
-    for key in merge_dct:
-        if (
-            key in dct
-            and isinstance(dct[key], dict)
-            and isinstance(merge_dct[key], collections.abc.Mapping)
-        ):
-            dct[key] = dict_merge(dct[key], merge_dct[key])
-        else:
-            dct[key] = merge_dct[key]
-
-    return dct
-
-
-def dataclass_schema(cls):
-    schema = {}
-    hints = typing.get_type_hints(cls)
-    for field, typ in hints.items():
-        field_types = [typ]
-
-        if typing.get_origin(typ) == typing.Union:
-            field_types = typing.get_args(typ)
-
-        for field_type in field_types:
-            if is_dataclass(field_type):
-                field_schema = dataclass_schema(field_type)
-            else:
-                field_schema = {}
-
-            schema = dict_merge(schema, {field: field_schema})
-
-    return schema
-
-
-def flatten_schema(schema: dict, separator: str = "_", level=None) -> list[str]:
-    flat_schema = []
-    for field, subschema in schema.items():
-        current_level = (level or []) + [field]
-        if subschema:
-            flat_schema.extend(
-                flatten_schema(subschema, separator, level=current_level)
-            )
-        else:
-            flat_schema.append(separator.join(current_level))
-
-    return flat_schema
-
-
-def dataframe_ensure_schema(df: pandas.DataFrame, obj: object) -> pandas.DataFrame:
-    schema = dataclass_schema(obj)
-    flat_schema = flatten_schema(schema, separator=".")
-
-    missing_cols = set(flat_schema) - set(df.columns)
-
-    return df.assign(**{col: None for col in missing_cols})
+from enlyze.schema import dataframe_ensure_schema  # , get_optional_dataclass_fields
 
 
 @dataclass(frozen=True)
@@ -374,72 +291,9 @@ class ProductionRun:
     #: Aggregate OEE score that comprises availability, performance and quality.
     productivity: Optional[OEEComponent]
 
-    def to_dict(self, exclude_unset_objects: bool = False) -> dict[str, Any]:
-        """Convert to Python dictionary.
-
-        The ``start`` and ``end`` fields will be represented as
-        :ref:`timezone-aware <python:datetime-naive-aware>`
-        :py:class:`datetime.datetime` localized in UTC.
-
-        :param exclude_unset_objects: Exclude fields that are typed as optional
-            dataclasses and set to ``None``.
-
-        :returns: Production run represented as Python dictionary.
-
-        """
-        data = asdict(
-            self,
-            dict_factory=lambda items: {
-                k: v
-                for k, v in items
-                if not (
-                    exclude_unset_objects
-                    and k in _get_optional_dataclass_fields(self)
-                    and v is None
-                )
-            },
-        )
-
-        data["start"] = data["start"].astimezone(timezone.utc)
-        if data["end"]:
-            data["end"] = data["end"].astimezone(timezone.utc)
-
-        return data
-
-    def to_dataframe(self) -> pandas.DataFrame:
-        """Convert to :py:class:`pandas.DataFrame`
-
-        The ``start`` and ``end`` fields will be represented as
-        :ref:`timezone-aware <python:datetime-naive-aware>`
-        :py:class:`datetime.datetime` localized in UTC.
-
-        :returns: DataFrame with a single row representing the production run.
-        """
-        return pandas.json_normalize(self.to_dict(exclude_unset_objects=True))
-
 
 class ProductionRuns(list[ProductionRun]):
     """Representation of multiple production runs."""
-
-    def to_dicts(self, exclude_unset_objects: bool = False) -> list[dict[str, Any]]:
-        """Convert to Python dictionaries.
-
-        The ``start`` and ``end`` fields will be represented as
-        :ref:`timezone-aware <python:datetime-naive-aware>`
-        :py:class:`datetime.datetime` localized in UTC.
-
-        :param exclude_unset_objects: Exclude fields that are typed as optional
-            dataclasses and set to ``None``.
-
-        :returns: List of Production runs represented as Python dictionaries.
-
-        """
-        return [
-            run.to_dict(
-                exclude_unset_objects=exclude_unset_objects,
-            )
-            for run in self
-        ]
 
     def to_dataframe(self) -> pandas.DataFrame:
         """Convert production runs into :py:class:`pandas.DataFrame`
@@ -453,6 +307,10 @@ class ProductionRuns(list[ProductionRun]):
         if not self:
             return pandas.DataFrame()
 
-        df = pandas.json_normalize(self.to_dicts(exclude_unset_objects=False))
+        path_separator = "."
 
-        return dataframe_ensure_schema(df, ProductionRun)
+        df = pandas.json_normalize([asdict(run) for run in self], sep=path_separator)
+        df.start = pandas.to_datetime(df.start, utc=True, format="ISO8601")
+        df.end = pandas.to_datetime(df.end, utc=True, format="ISO8601")
+
+        return dataframe_ensure_schema(df, ProductionRun, path_separator=path_separator)

--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import pandas
 
-from enlyze.schema import dataframe_ensure_schema  # , get_optional_dataclass_fields
+from enlyze.schema import dataframe_ensure_schema
 
 
 @dataclass(frozen=True)

--- a/src/enlyze/schema.py
+++ b/src/enlyze/schema.py
@@ -1,134 +1,58 @@
 import typing
-from collections.abc import Mapping
-from copy import deepcopy
 from dataclasses import is_dataclass
 from types import UnionType
-from typing import Any, ClassVar, Protocol
+from typing import Any, Protocol
 
 import pandas
 
 
-class IsDataclass(Protocol):
+class DataclassTypeOrInstance(Protocol):
     __dataclass_fields__: dict[str, Any]
 
 
-# def get_optional_dataclass_fields(obj: IsDataclass) -> set[str]:
-#     """Extract optional dataclass fields from ``obj``."""
-#     optional_fields = set()
-#     for field, typ in typing.get_type_hints(obj).items():
-#         # typing.Optional[T] is represented as typing.Union[None, T]
-#         if typing.get_origin(typ) != UnionType:
-#             continue
-
-#         union_args = list(typing.get_args(typ))
-
-#         try:
-#             union_args.remove(type(None))
-#         except ValueError:
-#             # None wasn't part of Union, so not optional
-#             continue
-
-#         if any(is_dataclass(arg) for arg in union_args):
-#             optional_fields.add(field)
-
-#     return optional_fields
-
-
-# def _dict_deep_merge(dict_a: dict[Any, Any], dict_b: dict[Any, Any]) -> dict[Any, Any]:
-#     """Deep merge two dictionaries."""
-#     merged_dict = deepcopy(dict_a)
-
-#     for key in dict_b:
-#         if (
-#             key in merged_dict
-#             and isinstance(merged_dict[key], dict)
-#             and isinstance(dict_b[key], Mapping)
-#         ):
-#             merged_dict[key] = _dict_deep_merge(merged_dict[key], dict_b[key])
-#         else:
-#             merged_dict[key] = dict_b[key]
-
-#     return merged_dict
-
-
-# def _dataclass_schema(obj: IsDataclass) -> dict[str, Any]:
-#     schema: dict[str, Any] = {}
-
-#     for field, typ in typing.get_type_hints(obj).items():
-#         field_types = (typ,)
-
-#         if typing.get_origin(typ) == UnionType:
-#             field_types = typing.get_args(typ)
-
-#         for field_type in field_types:
-#             if is_dataclass(field_type):
-#                 field_schema = _dataclass_schema(field_type)
-#             else:
-#                 field_schema = {}
-
-#             print(f"{field}: ({field_type}) -> {field_schema}")
-#             schema = _dict_deep_merge(schema, {field: field_schema})
-
-#     return schema
-
-
-# def _flatten_schema(
-#     schema: dict[str, Any],
-#     separator: str = "_",
-#     path: list[str] = [],
-# ) -> list[str]:
-#     flat_schema: list[str] = []
-
-#     for field, sub_schema in schema.items():
-#         current_path = path + [field]
-#         if sub_schema:
-#             flat_schema.extend(
-#                 _flatten_schema(
-#                     schema=sub_schema,
-#                     separator=separator,
-#                     path=current_path,
-#                 )
-#             )
-#         else:
-#             flat_schema.append(separator.join(current_path))
-
-#     return flat_schema
-
-
-def _immediate_flat_dataclass_schema(
-    obj: IsDataclass,
+def _flat_dataclass_schema(
+    dataclass_obj_or_type: DataclassTypeOrInstance,
     path_separator: str,
-    path: list[str] = [],
-) -> set[str]:
-    flat: set[str] = set()
+    _parent_path: list[str] = [],
+) -> list[str]:
+    """Derive flat schema of potentially nested dataclass ``dataclass_obj_or_type``"""
 
-    for field, typ in typing.get_type_hints(obj).items():
-        current_path = path + [field]
+    flat: list[str] = []
 
+    for field, typ in typing.get_type_hints(dataclass_obj_or_type).items():
+        current_path = _parent_path + [field]
         field_types = (typ,)
-        if typing.get_origin(typ) == UnionType:
+
+        # expand union types (includes typing.Optional)
+        origin_type = typing.get_origin(typ)
+        if origin_type is UnionType or origin_type is typing.Union:
             field_types = typing.get_args(typ)
 
         for field_type in field_types:
             if is_dataclass(field_type):
-                sub_schema = _immediate_flat_dataclass_schema(
-                    field_type, path_separator, current_path
+                flat.extend(
+                    _flat_dataclass_schema(field_type, path_separator, current_path)
                 )
-                flat.update(sub_schema)
             elif field_type != type(None):
-                flat.add(path_separator.join(current_path))
+                flat.append(path_separator.join(current_path))
 
-    return flat
+    # dedupe while preserving order
+    return list(dict.fromkeys(flat))
 
 
 def dataframe_ensure_schema(
     df: pandas.DataFrame,
-    obj: IsDataclass,
+    dataclass_obj_or_type: DataclassTypeOrInstance,
     path_separator: str = ".",
 ) -> pandas.DataFrame:
-    """Derive flat schema of nested dataclass ``obj`` and add missing columns to ``df``"""
+    """Add missing columns to ``df`` based on flattened schema of ``dataclass_obj_or_type``"""
 
-    flat_schema = _immediate_flat_dataclass_schema(obj, path_separator=path_separator)
-    missing_columns = set(flat_schema) - set(df.columns)
+    flat_schema = _flat_dataclass_schema(
+        dataclass_obj_or_type,
+        path_separator=path_separator,
+    )
 
-    return df.assign(**{col: None for col in missing_columns})
+    add_colums = set(flat_schema) - set(df.columns)
+    remove_columns = set(df.columns) - set(flat_schema)
+
+    return df.assign(**{col: None for col in add_colums}).drop(columns=remove_columns)

--- a/src/enlyze/schema.py
+++ b/src/enlyze/schema.py
@@ -33,7 +33,7 @@ def _flat_dataclass_schema(
                 flat.extend(
                     _flat_dataclass_schema(field_type, path_separator, current_path)
                 )
-            elif field_type != type(None):
+            elif field_type is not type(None):
                 flat.append(path_separator.join(current_path))
 
     # dedupe while preserving order
@@ -45,7 +45,7 @@ def dataframe_ensure_schema(
     dataclass_obj_or_type: DataclassTypeOrInstance,
     path_separator: str = ".",
 ) -> pandas.DataFrame:
-    """Add missing columns to ``df`` based on flattened schema of ``dataclass_obj_or_type``"""
+    """Add missing columns to ``df`` based on flattened dataclass schema"""
 
     flat_schema = _flat_dataclass_schema(
         dataclass_obj_or_type,

--- a/src/enlyze/schema.py
+++ b/src/enlyze/schema.py
@@ -55,4 +55,8 @@ def dataframe_ensure_schema(
     add_colums = set(flat_schema) - set(df.columns)
     remove_columns = set(df.columns) - set(flat_schema)
 
-    return df.assign(**{col: None for col in add_colums}).drop(columns=remove_columns)
+    return df.assign(
+        **{col: None for col in add_colums},
+    ).drop(
+        columns=list(remove_columns),
+    )

--- a/src/enlyze/schema.py
+++ b/src/enlyze/schema.py
@@ -1,0 +1,134 @@
+import typing
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import is_dataclass
+from types import UnionType
+from typing import Any, ClassVar, Protocol
+
+import pandas
+
+
+class IsDataclass(Protocol):
+    __dataclass_fields__: dict[str, Any]
+
+
+# def get_optional_dataclass_fields(obj: IsDataclass) -> set[str]:
+#     """Extract optional dataclass fields from ``obj``."""
+#     optional_fields = set()
+#     for field, typ in typing.get_type_hints(obj).items():
+#         # typing.Optional[T] is represented as typing.Union[None, T]
+#         if typing.get_origin(typ) != UnionType:
+#             continue
+
+#         union_args = list(typing.get_args(typ))
+
+#         try:
+#             union_args.remove(type(None))
+#         except ValueError:
+#             # None wasn't part of Union, so not optional
+#             continue
+
+#         if any(is_dataclass(arg) for arg in union_args):
+#             optional_fields.add(field)
+
+#     return optional_fields
+
+
+# def _dict_deep_merge(dict_a: dict[Any, Any], dict_b: dict[Any, Any]) -> dict[Any, Any]:
+#     """Deep merge two dictionaries."""
+#     merged_dict = deepcopy(dict_a)
+
+#     for key in dict_b:
+#         if (
+#             key in merged_dict
+#             and isinstance(merged_dict[key], dict)
+#             and isinstance(dict_b[key], Mapping)
+#         ):
+#             merged_dict[key] = _dict_deep_merge(merged_dict[key], dict_b[key])
+#         else:
+#             merged_dict[key] = dict_b[key]
+
+#     return merged_dict
+
+
+# def _dataclass_schema(obj: IsDataclass) -> dict[str, Any]:
+#     schema: dict[str, Any] = {}
+
+#     for field, typ in typing.get_type_hints(obj).items():
+#         field_types = (typ,)
+
+#         if typing.get_origin(typ) == UnionType:
+#             field_types = typing.get_args(typ)
+
+#         for field_type in field_types:
+#             if is_dataclass(field_type):
+#                 field_schema = _dataclass_schema(field_type)
+#             else:
+#                 field_schema = {}
+
+#             print(f"{field}: ({field_type}) -> {field_schema}")
+#             schema = _dict_deep_merge(schema, {field: field_schema})
+
+#     return schema
+
+
+# def _flatten_schema(
+#     schema: dict[str, Any],
+#     separator: str = "_",
+#     path: list[str] = [],
+# ) -> list[str]:
+#     flat_schema: list[str] = []
+
+#     for field, sub_schema in schema.items():
+#         current_path = path + [field]
+#         if sub_schema:
+#             flat_schema.extend(
+#                 _flatten_schema(
+#                     schema=sub_schema,
+#                     separator=separator,
+#                     path=current_path,
+#                 )
+#             )
+#         else:
+#             flat_schema.append(separator.join(current_path))
+
+#     return flat_schema
+
+
+def _immediate_flat_dataclass_schema(
+    obj: IsDataclass,
+    path_separator: str,
+    path: list[str] = [],
+) -> set[str]:
+    flat: set[str] = set()
+
+    for field, typ in typing.get_type_hints(obj).items():
+        current_path = path + [field]
+
+        field_types = (typ,)
+        if typing.get_origin(typ) == UnionType:
+            field_types = typing.get_args(typ)
+
+        for field_type in field_types:
+            if is_dataclass(field_type):
+                sub_schema = _immediate_flat_dataclass_schema(
+                    field_type, path_separator, current_path
+                )
+                flat.update(sub_schema)
+            elif field_type != type(None):
+                flat.add(path_separator.join(current_path))
+
+    return flat
+
+
+def dataframe_ensure_schema(
+    df: pandas.DataFrame,
+    obj: IsDataclass,
+    path_separator: str = ".",
+) -> pandas.DataFrame:
+    """Derive flat schema of nested dataclass ``obj`` and add missing columns to ``df``"""
+
+    flat_schema = _immediate_flat_dataclass_schema(obj, path_separator=path_separator)
+    missing_columns = set(flat_schema) - set(df.columns)
+
+    return df.assign(**{col: None for col in missing_columns})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,22 @@ from hypothesis import strategies as st
 hypothesis.settings.register_profile("ci", deadline=None)
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
+PANDAS_MIN_DATETIME = datetime(1677, 9, 21, 0, 12, 44)
+PANDAS_MAX_DATETIME = datetime(2262, 4, 11, 23, 47, 16)
+
+# https://github.com/python/cpython/issues/94414
+WINDOWS_MIN_DATETIME = datetime(1970, 1, 2, 1, 0, 0)
+WINDOWS_MAX_DATETIME = datetime(3001, 1, 19, 7, 59, 59)
+
+st.register_type_strategy(
+    datetime,
+    st.datetimes(
+        min_value=max(PANDAS_MIN_DATETIME, WINDOWS_MIN_DATETIME),
+        max_value=min(PANDAS_MAX_DATETIME, WINDOWS_MAX_DATETIME),
+    ),
+)
+
 datetime_today_until_now_strategy = st.datetimes(
     min_value=datetime.now().replace(hour=0),
     max_value=datetime.now(),

--- a/tests/enlyze/test_models.py
+++ b/tests/enlyze/test_models.py
@@ -7,11 +7,18 @@ from hypothesis import given
 from enlyze.models import ProductionRun, ProductionRuns, _get_optional_dataclass_fields
 
 # https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
+PANDAS_MIN_DATETIME = datetime(1677, 9, 21, 0, 12, 44)
+PANDAS_MAX_DATETIME = datetime(2262, 4, 11, 23, 47, 16)
+
+# https://github.com/python/cpython/issues/94414
+WINDOWS_MIN_DATETIME = datetime(1970, 1, 2, 1, 0, 0)
+WINDOWS_MAX_DATETIME = datetime(3001, 1, 19, 7, 59, 59)
+
 st.register_type_strategy(
     datetime,
     st.datetimes(
-        min_value=datetime(1677, 9, 21, 0, 12, 44),
-        max_value=datetime(2262, 4, 11, 23, 47, 16),
+        min_value=max(PANDAS_MIN_DATETIME, WINDOWS_MIN_DATETIME),
+        max_value=min(PANDAS_MAX_DATETIME, WINDOWS_MAX_DATETIME),
     ),
 )
 

--- a/tests/enlyze/test_models.py
+++ b/tests/enlyze/test_models.py
@@ -1,37 +1,30 @@
 from dataclasses import replace
-from datetime import datetime
 
 import hypothesis.strategies as st
 from hypothesis import given
 
-from enlyze.models import ProductionRun, ProductionRuns, _get_optional_dataclass_fields
+from enlyze.models import ProductionRun, ProductionRuns
 
-# https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
-PANDAS_MIN_DATETIME = datetime(1677, 9, 21, 0, 12, 44)
-PANDAS_MAX_DATETIME = datetime(2262, 4, 11, 23, 47, 16)
 
-# https://github.com/python/cpython/issues/94414
-WINDOWS_MIN_DATETIME = datetime(1970, 1, 2, 1, 0, 0)
-WINDOWS_MAX_DATETIME = datetime(3001, 1, 19, 7, 59, 59)
-
-st.register_type_strategy(
-    datetime,
-    st.datetimes(
-        min_value=max(PANDAS_MIN_DATETIME, WINDOWS_MIN_DATETIME),
-        max_value=min(PANDAS_MAX_DATETIME, WINDOWS_MAX_DATETIME),
-    ),
-)
+@given(runs=st.lists(st.from_type(ProductionRun), max_size=10))
+def test_production_runs_to_dataframe(runs: list[ProductionRun]):
+    runs = ProductionRuns(runs)
+    runs.to_dataframe()
 
 
 @given(run=st.from_type(ProductionRun))
-def test_production_run_to_dict_exclude_unset_objects(run: ProductionRun):
-    run = replace(run, quality=None)
-    assert "quality" in run.to_dict(exclude_unset_objects=False)
-    assert "quality" not in run.to_dict(exclude_unset_objects=True)
+def test_production_runs_to_dataframe_no_empty_columns_for_optional_dataclasses(
+    run: ProductionRun,
+):
+    df = ProductionRuns(
+        [
+            replace(
+                run,
+                average_throughput=None,
+                quantity_total=None,
+            )
+        ]
+    ).to_dataframe()
 
-
-# @given(runs=st.lists(st.from_type(ProductionRun), max_size=10))
-# def test_production_runs_to_dataframe(runs: list[ProductionRun]):
-#     runs = ProductionRuns(runs)
-#     df = runs.to_dataframe()
-#     assert not set(df) & _get_optional_dataclass_fields(ProductionRun)
+    assert "quantity_total" not in df.columns
+    assert "average_throughput" in df.columns

--- a/tests/enlyze/test_models.py
+++ b/tests/enlyze/test_models.py
@@ -30,8 +30,8 @@ def test_production_run_to_dict_exclude_unset_objects(run: ProductionRun):
     assert "quality" not in run.to_dict(exclude_unset_objects=True)
 
 
-@given(runs=st.lists(st.from_type(ProductionRun), max_size=10))
-def test_production_runs_to_dataframe(runs: list[ProductionRun]):
-    runs = ProductionRuns(runs)
-    df = runs.to_dataframe()
-    assert not set(df) & _get_optional_dataclass_fields(ProductionRun)
+# @given(runs=st.lists(st.from_type(ProductionRun), max_size=10))
+# def test_production_runs_to_dataframe(runs: list[ProductionRun]):
+#     runs = ProductionRuns(runs)
+#     df = runs.to_dataframe()
+#     assert not set(df) & _get_optional_dataclass_fields(ProductionRun)

--- a/tests/enlyze/test_models.py
+++ b/tests/enlyze/test_models.py
@@ -1,0 +1,30 @@
+from dataclasses import replace
+from datetime import datetime
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+from enlyze.models import ProductionRun, ProductionRuns, _get_optional_dataclass_fields
+
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
+st.register_type_strategy(
+    datetime,
+    st.datetimes(
+        min_value=datetime(1677, 9, 21, 0, 12, 44),
+        max_value=datetime(2262, 4, 11, 23, 47, 16),
+    ),
+)
+
+
+@given(run=st.from_type(ProductionRun))
+def test_production_run_to_dict_exclude_unset_objects(run: ProductionRun):
+    run = replace(run, quality=None)
+    assert "quality" in run.to_dict(exclude_unset_objects=False)
+    assert "quality" not in run.to_dict(exclude_unset_objects=True)
+
+
+@given(runs=st.lists(st.from_type(ProductionRun), max_size=10))
+def test_production_runs_to_dataframe(runs: list[ProductionRun]):
+    runs = ProductionRuns(runs)
+    df = runs.to_dataframe()
+    assert not set(df) & _get_optional_dataclass_fields(ProductionRun)

--- a/tests/enlyze/test_schema.py
+++ b/tests/enlyze/test_schema.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import pandas
 
-from enlyze.schema import dataframe_ensure_schema  # get_optional_dataclass_fields,
+from enlyze.schema import dataframe_ensure_schema
 
 
 @dataclass
@@ -18,10 +18,6 @@ class Thing:
     multiple_but_required: float | str | Some
 
 
-# def test_get_optional_dataclass_fields():
-#     assert get_optional_dataclass_fields(Thing) == {"maybe_some"}
-
-
 def test_dataframe_ensure_schema():
     df = pandas.DataFrame()
 
@@ -34,13 +30,3 @@ def test_dataframe_ensure_schema():
         "multiple_but_required",
         "multiple_but_required|a",
     }
-
-
-# def test_immediate_flat():
-#     assert _immediate_flat_dataclass_schema(Thing, path_separator="|") == {
-#         "number",
-#         "maybe_string",
-#         "maybe_some|a",
-#         "multiple_but_required",
-#         "multiple_but_required|a",
-#     }

--- a/tests/enlyze/test_schema.py
+++ b/tests/enlyze/test_schema.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+import pandas
+
+from enlyze.schema import dataframe_ensure_schema  # get_optional_dataclass_fields,
+
+
+@dataclass
+class Some:
+    a: int
+
+
+@dataclass
+class Thing:
+    number: int
+    maybe_string: str | None
+    maybe_some: Some | None
+    multiple_but_required: float | str | Some
+
+
+# def test_get_optional_dataclass_fields():
+#     assert get_optional_dataclass_fields(Thing) == {"maybe_some"}
+
+
+def test_dataframe_ensure_schema():
+    df = pandas.DataFrame()
+
+    added_columns = set(dataframe_ensure_schema(df, Thing, path_separator="|").columns)
+
+    assert added_columns == {
+        "number",
+        "maybe_string",
+        "maybe_some|a",
+        "multiple_but_required",
+        "multiple_but_required|a",
+    }
+
+
+# def test_immediate_flat():
+#     assert _immediate_flat_dataclass_schema(Thing, path_separator="|") == {
+#         "number",
+#         "maybe_string",
+#         "maybe_some|a",
+#         "multiple_but_required",
+#         "multiple_but_required|a",
+#     }


### PR DESCRIPTION
The `ProductionRun` dataclass contains some fields that in turn are dataclasses themselves. When such fields are turned into DataFrame columns, they are flattened such that every field contained in the sub-objects becomes a column in the final DataFrame. Since some of these fields are actually optional, also the field name itself will turn into a column which in practice always is `None`. This PR removes such useless columns from the DataFrame.

Moreover, if any of the optional dataclass fields is empty for all production runs, then their sub fields would not become part of the DataFrame. This can be annoying when building services on top of the SDK, because you cannot assume that a column would be part of the DataFrame, thus requiring checks everywhere. Therefore, we now enforce the schema of the returned DataFrame. This means, that irrespective of the underlying data, all nested fields will be always be present as flattened columns in the DataFrame.