### PR TITLE
Fix PR-comment GitHub Action by using our forked version.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Report test coverage
         if: ${{ matrix.coverage-report == true }}
-        uses: rhs/pr-comment@1.0.4
+        uses: enlyze/pr-comment@v1.0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -96,7 +96,6 @@ class EnlyzeClient:
 
         :param site: Only get appliances of this site. Gets all appliances of the
             organization if None.
-        :type site: :class:`~enlyze.models.Site` or None
 
         :raises: |token-error|
 
@@ -138,7 +137,6 @@ class EnlyzeClient:
         """Retrieve all variables of an :ref:`appliance <appliance>`.
 
         :param appliance: The appliance for which to get all variables.
-        :type appliance: :class:`~enlyze.models.Appliance`
 
         :raises: |token-error|
 


### PR DESCRIPTION
I had to remove a problematic type annotation in the docstring of `EnlyzeClient.get_appliances()` as well, because that has led to a failure building the docs. For consistency, I've also removed a similar annotation in the same class. Both annotation are not strictly necessary, so this shouldn't be a big deal.