### PR TITLE
Rename `appliance` to `machine` in the example notebook.

### DIFF
--- a/examples/notebooks/introduction_enlyze_python_sdk.ipynb
+++ b/examples/notebooks/introduction_enlyze_python_sdk.ipynb
@@ -8,11 +8,11 @@
     "# Introduction to the ENLYZE Python SDK\n",
     "---\n",
     "This guide introduces you to the concepts of the ENLYZE platform and shows you how they are implemented in the Python SDK.\n",
-    "We will use the SDK to query information about different locations and appliances (machines), and ultimately query time series data of one appliance to further analyze and process it. \n",
+    "We will use the SDK to query information about different locations and machines, and ultimately query time series data of one machine to further analyze and process it. \n",
     "\n",
     "In the second half, we will query production runs and OEE KPIs and prepare the data to be exported to Excel or used by Power BI.\n",
     "\n",
-    "All is based on our demo organization, which represents an imaginary company with several locations, exemplary appliances and dummy time series data."
+    "All is based on our demo organization, which represents an imaginary company with several locations, exemplary machines and dummy time series data."
    ]
   },
   {
@@ -153,9 +153,9 @@
    "id": "1be58d63-b9e6-4037-abd5-870e2fdac2be",
    "metadata": {},
    "source": [
-    "## Sites, Appliances (Machines), and Variables\n",
+    "## Sites, Machines, and Variables\n",
     "\n",
-    "These three are the core models to interact with the platform. An organization consists of one or multiple sites, which again hold one or multiple appliances. Each appliance has then a set of variables. A variable represents a process measure of one appliance of which timeseries data is captured and stored in the ENLYZE platform. One appliance can have many variables, whereas one variable is only associated with one appliance.\n",
+    "These three are the core models to interact with the platform. An organization consists of one or multiple sites, which again hold one or multiple machines. Each machine has then a set of variables. A variable represents a process measure of one machine of which timeseries data is captured and stored in the ENLYZE platform. One machine can have many variables, whereas one variable is only associated with one machine.\n",
     "\n",
     "To get variables, we need to traverse down this tree until we get and select the variables we want, and then use these variables to query their data.\n",
     "\n",
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from enlyze.models import Site, Appliance, Variable"
+    "from enlyze.models import Site, Machine, Variable"
    ]
   },
   {
@@ -225,7 +225,7 @@
     "\n",
     "Due to its many advantages for data processing and widespread use in the Python ecosystem, it is already part of the enlyze package and is installed alongside as a requirement.\n",
     "\n",
-    "Especially in [Jupyter Notebooks](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html) it makes working with and visualizing data straightforward. You will notice that models (Site, Appliances, Variables etc.) have different attributes and are often returned in a list. For a few models and properties, printing the list in its raw form is still sufficient. But we soon reach the limits, and it becomes confusing and unmanageable. For this, we have this small utility function `models_to_dataframe` that takes a list of models and returns them as a DataFrame. This makes it a lot easier to explore data."
+    "Especially in [Jupyter Notebooks](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html) it makes working with and visualizing data straightforward. You will notice that models (Site, Machines, Variables etc.) have different attributes and are often returned in a list. For a few models and properties, printing the list in its raw form is still sufficient. But we soon reach the limits, and it becomes confusing and unmanageable. For this, we have this small utility function `models_to_dataframe` that takes a list of models and returns them as a DataFrame. This makes it a lot easier to explore data."
    ]
   },
   {
@@ -347,7 +347,7 @@
    "id": "734921aa-f1c8-4254-9569-74f7e90e7db4",
    "metadata": {},
    "source": [
-    "### Appliances"
+    "### Machines"
    ]
   },
   {
@@ -355,7 +355,7 @@
    "id": "1aae646d-d47b-434e-a90e-daec386a6802",
    "metadata": {},
    "source": [
-    "We can get a list of all appliances by using the `get_appliances` method. Optionally, we can pass a site to the function to filter by it."
+    "We can get a list of all machines by using the `get_machines` method. Optionally, we can pass a site to the function to filter by it."
    ]
   },
   {
@@ -462,7 +462,7 @@
     }
    ],
    "source": [
-    "models_to_dataframe(enlyze.get_appliances())"
+    "models_to_dataframe(enlyze.get_machines())"
    ]
   },
   {
@@ -470,7 +470,7 @@
    "id": "4c378054-420f-405f-a033-1270e948d538",
    "metadata": {},
    "source": [
-    "Filtering by site will only return the respective appliances:"
+    "Filtering by site will only return the respective machines:"
    ]
   },
   {
@@ -550,8 +550,8 @@
     }
    ],
    "source": [
-    "cologne_appliances = enlyze.get_appliances(site=site)\n",
-    "models_to_dataframe(cologne_appliances)"
+    "cologne_machines = enlyze.get_machines(site=site)\n",
+    "models_to_dataframe(cologne_machines)"
    ]
   },
   {
@@ -559,9 +559,9 @@
    "id": "c6a57053-edac-4fcc-b3df-795ff9441d42",
    "metadata": {},
    "source": [
-    "**Selecting an appliance by UUID**\n",
+    "**Selecting a machine by UUID**\n",
     "\n",
-    "A more reliable way to select an appliance from the list is filtering by `UUID`. Attributes like the name may change over time, but the assigned `UUID` will stay unchanged."
+    "A more reliable way to select a machine from the list is filtering by `UUID`. Attributes like the name may change over time, but the assigned `UUID` will stay unchanged."
    ]
   },
   {
@@ -581,7 +581,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "APPLIANCE_UUID = UUID(\"22a71d1e-8262-4c27-b5fb-66598027936a\")"
+    "MACHINE_UUID = UUID(\"22a71d1e-8262-4c27-b5fb-66598027936a\")"
    ]
   },
   {
@@ -589,7 +589,7 @@
    "id": "2daff658-0ed4-4564-8a9f-b182cbbc436a",
    "metadata": {},
    "source": [
-    "We can create a function, that returns the appliance, if it matches the UUID:"
+    "We can create a function, that returns the machine, if it matches the UUID:"
    ]
   },
   {
@@ -599,10 +599,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_appliance_by_uuid(uuid: UUID, appliances: list[Appliance]):\n",
-    "    for appliance in appliances:\n",
-    "        if appliance.uuid == uuid:\n",
-    "            return appliance\n",
+    "def get_machine_by_uuid(uuid: UUID, machines: list[Machine]):\n",
+    "    for machine in machines:\n",
+    "        if machine.uuid == uuid:\n",
+    "            return machine\n",
     "            "
    ]
   },
@@ -615,7 +615,7 @@
     {
      "data": {
       "text/plain": [
-       "Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-66598027936a'), display_name='W&H Varex', genesis_date=datetime.date(2022, 3, 18), site=Site(_id=32, display_name='Köln', address='Heliosstrasse 6a'))"
+       "Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-66598027936a'), display_name='W&H Varex', genesis_date=datetime.date(2022, 3, 18), site=Site(_id=32, display_name='Köln', address='Heliosstrasse 6a'))"
       ]
      },
      "execution_count": 15,
@@ -624,7 +624,7 @@
     }
    ],
    "source": [
-    "get_appliance_by_uuid(APPLIANCE_UUID, cologne_appliances)"
+    "get_machine_by_uuid(MACHINE_UUID, cologne_machines)"
    ]
   },
   {
@@ -644,7 +644,7 @@
     {
      "data": {
       "text/plain": [
-       "Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-66598027936a'), display_name='W&H Varex', genesis_date=datetime.date(2022, 3, 18), site=Site(_id=32, display_name='Köln', address='Heliosstrasse 6a'))"
+       "Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-66598027936a'), display_name='W&H Varex', genesis_date=datetime.date(2022, 3, 18), site=Site(_id=32, display_name='Köln', address='Heliosstrasse 6a'))"
       ]
      },
      "execution_count": 16,
@@ -653,10 +653,10 @@
     }
    ],
    "source": [
-    "results = filter(lambda a: a.uuid == APPLIANCE_UUID, cologne_appliances)\n",
-    "appliance = next(results)\n",
+    "results = filter(lambda a: a.uuid == MACHINE_UUID, cologne_machines)\n",
+    "machine = next(results)\n",
     "\n",
-    "appliance"
+    "machine"
    ]
   },
   {
@@ -666,7 +666,7 @@
    "source": [
     "### Variables\n",
     "\n",
-    "The last step we need to make is getting the variables for an appliance. We use the `get_variables`method, which always requires the specification of an appliance."
+    "The last step we need to make is getting the variables for a machine. We use the `get_variables`method, which always requires the specification of an machine."
    ]
   },
   {
@@ -676,7 +676,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "variables = enlyze.get_variables(appliance)"
+    "variables = enlyze.get_variables(machine)"
    ]
   },
   {
@@ -720,7 +720,7 @@
        "      <th>display_name</th>\n",
        "      <th>unit</th>\n",
        "      <th>data_type</th>\n",
-       "      <th>appliance</th>\n",
+       "      <th>machine</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -730,7 +730,7 @@
        "      <td>Extruder C Schneckenumdrehung</td>\n",
        "      <td>1/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -738,7 +738,7 @@
        "      <td>Extruder A Schmelzedruck</td>\n",
        "      <td>bar</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -746,7 +746,7 @@
        "      <td>Extruder C Schmelzedruck</td>\n",
        "      <td>bar</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -754,7 +754,7 @@
        "      <td>Extruder I Schneckenumdrehung</td>\n",
        "      <td>1/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -762,7 +762,7 @@
        "      <td>Anzahl Messungen</td>\n",
        "      <td>n</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -776,12 +776,12 @@
        "3  094853e6-702d-43ab-a612-15ea0dfc90c3  Extruder I Schneckenumdrehung  1/min   \n",
        "4  0b8af028-7bea-4b71-8719-48bb8c57505d               Anzahl Messungen      n   \n",
        "\n",
-       "                  data_type                                          appliance  \n",
-       "0  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "1  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "2  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "3  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "4  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
+       "                  data_type                                          machine  \n",
+       "0  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "1  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "2  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "3  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "4  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
       ]
      },
      "execution_count": 19,
@@ -838,7 +838,7 @@
        "      <th>display_name</th>\n",
        "      <th>unit</th>\n",
        "      <th>data_type</th>\n",
-       "      <th>appliance</th>\n",
+       "      <th>machine</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -848,7 +848,7 @@
        "      <td>2-Sigma</td>\n",
        "      <td>%</td>\n",
        "      <td>VariableDataType.FLOAT</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -856,7 +856,7 @@
        "      <td>Abzugsgeschwindigkeit</td>\n",
        "      <td>m/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -864,7 +864,7 @@
        "      <td>Anzahl Messungen</td>\n",
        "      <td>n</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -872,7 +872,7 @@
        "      <td>Durchsatz</td>\n",
        "      <td>kg/h</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -880,7 +880,7 @@
        "      <td>Extruder A Durchsatz</td>\n",
        "      <td>kg/h</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -894,12 +894,12 @@
        "3  f0e3d6cc-d302-4b0f-a660-8217f1b5d1ea              Durchsatz   kg/h   \n",
        "4  378f5c4f-958e-4d72-98dc-88b6ac700b4b   Extruder A Durchsatz   kg/h   \n",
        "\n",
-       "                  data_type                                          appliance  \n",
-       "0    VariableDataType.FLOAT  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "1  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "2  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "3  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "4  VariableDataType.INTEGER  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
+       "                  data_type                                          machine  \n",
+       "0    VariableDataType.FLOAT  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "1  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "2  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "3  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "4  VariableDataType.INTEGER  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
       ]
      },
      "execution_count": 21,
@@ -950,7 +950,7 @@
        "      <th>display_name</th>\n",
        "      <th>unit</th>\n",
        "      <th>data_type</th>\n",
-       "      <th>appliance</th>\n",
+       "      <th>machine</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -960,7 +960,7 @@
        "      <td>Extruder A Durchsatz</td>\n",
        "      <td>kg/h</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -968,7 +968,7 @@
        "      <td>Extruder A Folienstärke</td>\n",
        "      <td>µm</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -976,7 +976,7 @@
        "      <td>Extruder A Förderrate</td>\n",
        "      <td>kg/U/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -984,7 +984,7 @@
        "      <td>Extruder A Schmelzedruck</td>\n",
        "      <td>bar</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -992,7 +992,7 @@
        "      <td>Extruder A Schmelzetemperatur</td>\n",
        "      <td>°C</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
@@ -1000,7 +1000,7 @@
        "      <td>Extruder A Schneckenumdrehung</td>\n",
        "      <td>1/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1023,13 +1023,13 @@
        "8        °C  VariableDataType.INTEGER   \n",
        "9     1/min  VariableDataType.INTEGER   \n",
        "\n",
-       "                                           appliance  \n",
-       "4  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "5  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "6  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "7  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "8  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "9  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
+       "                                           machine  \n",
+       "4  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "5  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "6  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "7  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "8  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "9  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
       ]
      },
      "execution_count": 22,
@@ -1080,7 +1080,7 @@
        "      <th>display_name</th>\n",
        "      <th>unit</th>\n",
        "      <th>data_type</th>\n",
-       "      <th>appliance</th>\n",
+       "      <th>machine</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1090,7 +1090,7 @@
        "      <td>Extruder A Durchsatz</td>\n",
        "      <td>kg/h</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -1098,7 +1098,7 @@
        "      <td>Extruder A Folienstärke</td>\n",
        "      <td>µm</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -1106,7 +1106,7 @@
        "      <td>Extruder A Förderrate</td>\n",
        "      <td>kg/U/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -1114,7 +1114,7 @@
        "      <td>Extruder A Schmelzedruck</td>\n",
        "      <td>bar</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -1122,7 +1122,7 @@
        "      <td>Extruder A Schmelzetemperatur</td>\n",
        "      <td>°C</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
@@ -1130,7 +1130,7 @@
        "      <td>Extruder A Schneckenumdrehung</td>\n",
        "      <td>1/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
@@ -1138,7 +1138,7 @@
        "      <td>Extruder B Durchsatz</td>\n",
        "      <td>kg/h</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
@@ -1146,7 +1146,7 @@
        "      <td>Extruder B Folienstärke</td>\n",
        "      <td>µm</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
@@ -1154,7 +1154,7 @@
        "      <td>Extruder B Förderrate</td>\n",
        "      <td>kg/U/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
@@ -1162,7 +1162,7 @@
        "      <td>Extruder B Schmelzedruck</td>\n",
        "      <td>bar</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
@@ -1170,7 +1170,7 @@
        "      <td>Extruder B Schmelzetemperatur</td>\n",
        "      <td>°C</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
@@ -1178,7 +1178,7 @@
        "      <td>Extruder B Schneckenumdrehung</td>\n",
        "      <td>1/min</td>\n",
        "      <td>VariableDataType.INTEGER</td>\n",
-       "      <td>Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
+       "      <td>Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1213,19 +1213,19 @@
        "14        °C  VariableDataType.INTEGER   \n",
        "15     1/min  VariableDataType.INTEGER   \n",
        "\n",
-       "                                            appliance  \n",
-       "4   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "5   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "6   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "7   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "8   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "9   Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "10  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "11  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "12  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "13  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "14  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
-       "15  Appliance(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
+       "                                            machine  \n",
+       "4   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "5   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "6   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "7   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "8   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "9   Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "10  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "11  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "12  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "13  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "14  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  \n",
+       "15  Machine(uuid=UUID('22a71d1e-8262-4c27-b5fb-6...  "
       ]
      },
      "execution_count": 23,
@@ -1328,7 +1328,7 @@
     "It then returns a `TimeseriesData` object, from which the data can be retrieved as a pandas DataFrame or dictionary (records). By default, the column names will be set to the `variable_uuids` but if `use_display_names` is set to True, it will return the DataFrame with human-readable names.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Display names are not guaranteed to be unique for an appliance.\n",
+    "<b>Note:</b> Display names are not guaranteed to be unique for a machine.\n",
     "</div>\n",
     "\n",
     "If two or more variables with the same display name exist, there will be multiple columns with the same name. This can lead to unexpected behavior in later steps. However, display names can be adjusted in the app at any time, thus solving this problem.\n"
@@ -2357,7 +2357,7 @@
    "source": [
     "## Production runs\n",
     "If your production runs are integrated to the ENLYZE Platform, you can also use the `EnlyzeClient` to query them, alongside the calculated OEE metrics per run.\n",
-    "You can fetch all runs at once or use filters to fetch runs specific product, orders, appliances or within a certain time range."
+    "You can fetch all runs at once or use filters to fetch runs specific product, orders, machines or within a certain time range."
    ]
   },
   {
@@ -2365,7 +2365,7 @@
    "id": "1b25c5f8-82b6-40b3-aef4-ee5058d61842",
    "metadata": {},
    "source": [
-    "We will use our previously selected appliance from above to filter the runs. Since this is a demo account, the KPIs are not meaningful, but this should give you a good idea of the data and what is possible."
+    "We will use our previously selected machine from above to filter the runs. Since this is a demo account, the KPIs are not meaningful, but this should give you a good idea of the data and what is possible."
    ]
   },
   {
@@ -2375,7 +2375,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runs = enlyze.get_production_runs(appliance=appliance)"
+    "runs = enlyze.get_production_runs(machine=machine)"
    ]
   },
   {
@@ -2383,7 +2383,7 @@
    "id": "8086ac26-d0b9-4ec9-bf9b-6b0e26697725",
    "metadata": {},
    "source": [
-    "Unlike the time series data or the appliances, the runs are returned as a `enlyze.models.ProductionRuns` model. This model as a `to_dataframe` method, which conveniently converts the runs into a pandas DataFrame for us."
+    "Unlike the time series data or the machines, the runs are returned as a `enlyze.models.ProductionRuns` model. This model as a `to_dataframe` method, which conveniently converts the runs into a pandas DataFrame for us."
    ]
   },
   {
@@ -2755,12 +2755,12 @@
       " 8   performance                  0 non-null      float64            \n",
       " 9   quality                      0 non-null      float64            \n",
       " 10  productivity                 0 non-null      float64            \n",
-      " 11  appliance.uuid               227 non-null    object             \n",
-      " 12  appliance.display_name       227 non-null    object             \n",
-      " 13  appliance.genesis_date       227 non-null    object             \n",
-      " 14  appliance.site._id           227 non-null    int64              \n",
-      " 15  appliance.site.display_name  227 non-null    object             \n",
-      " 16  appliance.site.address       227 non-null    object             \n",
+      " 11  machine.uuid               227 non-null    object             \n",
+      " 12  machine.display_name       227 non-null    object             \n",
+      " 13  machine.genesis_date       227 non-null    object             \n",
+      " 14  machine.site._id           227 non-null    int64              \n",
+      " 15  machine.site.display_name  227 non-null    object             \n",
+      " 16  machine.site.address       227 non-null    object             \n",
       " 17  product.code                 227 non-null    object             \n",
       " 18  product.name                 0 non-null      object             \n",
       " 19  quantity_scrap.unit          213 non-null    object             \n",
@@ -2862,12 +2862,12 @@
       " 8   performance                  0 non-null      float64       \n",
       " 9   quality                      0 non-null      float64       \n",
       " 10  productivity                 0 non-null      float64       \n",
-      " 11  appliance.uuid               227 non-null    object        \n",
-      " 12  appliance.display_name       227 non-null    object        \n",
-      " 13  appliance.genesis_date       227 non-null    object        \n",
-      " 14  appliance.site._id           227 non-null    int64         \n",
-      " 15  appliance.site.display_name  227 non-null    object        \n",
-      " 16  appliance.site.address       227 non-null    object        \n",
+      " 11  machine.uuid               227 non-null    object        \n",
+      " 12  machine.display_name       227 non-null    object        \n",
+      " 13  machine.genesis_date       227 non-null    object        \n",
+      " 14  machine.site._id           227 non-null    int64         \n",
+      " 15  machine.site.display_name  227 non-null    object        \n",
+      " 16  machine.site.address       227 non-null    object        \n",
       " 17  product.code                 227 non-null    object        \n",
       " 18  product.name                 0 non-null      object        \n",
       " 19  quantity_scrap.unit          213 non-null    object        \n",


### PR DESCRIPTION
https://github.com/enlyze/enlyze-python/pull/37 renamed `appliance` to `machine` in the SDK, this PR renames all instances of `appliance` in the example notebook with `machine`.