### PR TITLE
Fix an issue where the SDK fails with a `TimeseriesServiceError` if querying time series data for more than 100 variables

### DIFF
--- a/src/enlyze/api_clients/timeseries/models.py
+++ b/src/enlyze/api_clients/timeseries/models.py
@@ -84,7 +84,7 @@ class TimeseriesData(TimeseriesApiModel):
                 f" with {slen} records."
             )
 
-        self.columns.extend(other.columns)
+        self.columns.extend(other.columns[1:])
 
         for s, o in zip(self.records, other.records):
             if s[0] != o[0]:

--- a/src/enlyze/api_clients/timeseries/models.py
+++ b/src/enlyze/api_clients/timeseries/models.py
@@ -75,6 +75,28 @@ class TimeseriesData(TimeseriesApiModel):
         """Add records from ``other`` after the existing records."""
         self.records.extend(other.records)
 
+    def merge(self, other: "TimeseriesData") -> "TimeseriesData":
+        """Merge records from ``other`` into the existing records."""
+        if not (slen := len(self.records)) == (olen := len(other.records)):
+            raise ValueError(
+                "Cannot merge. Number of records in both instances has to be the same,"
+                f" trying to merge an instance with {olen} records into an instance"
+                f" with {slen} records."
+            )
+
+        self.columns.extend(other.columns)
+
+        for s, o in zip(self.records, other.records):
+            if s[0] != o[0]:
+                raise ValueError(
+                    "Cannot merge. Attempted to merge records "
+                    f"with mismatched timestamps {s[0]}, {o[0]}"
+                )
+
+            s.extend(o[1:])
+
+        return self
+
     def to_user_model(
         self,
         start: datetime,

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -252,8 +252,18 @@ class EnlyzeClient:
         timeseries_data_chunked = [
             _get_timeseries_data_from_pages(pages) for pages in chunks_pages
         ]
-        if not timeseries_data_chunked or None in timeseries_data_chunked:
+
+        if not timeseries_data_chunked or all(
+            data is None for data in timeseries_data_chunked
+        ):
             return None
+
+        if any(data is None for data in timeseries_data_chunked) and any(
+            data is not None for data in timeseries_data_chunked
+        ):
+            raise EnlyzeError(
+                "The timeseries API didn't return data for some of the variables."
+            )
 
         try:
             timeseries_data = reduce(lambda x, y: x.merge(y), timeseries_data_chunked)  # type: ignore # noqa

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -24,7 +24,6 @@ from enlyze.validators import (
     validate_timeseries_arguments,
 )
 
-
 FETCHING_TIMESERIES_DATA_ERROR_MSG = "Error occurred when fetching timeseries data."
 
 

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -55,7 +55,9 @@ def _get_variables_sequence_and_query_parameter_list(
     resampling_interval: Optional[int],
 ) -> Tuple[Sequence[user_models.Variable], Sequence[str]]:
     if isinstance(variables, abc.Sequence) and resampling_interval is not None:
-        raise ResamplingValidationError("`variables` must be a mapping {variable: ResamplingMethod}")
+        raise ResamplingValidationError(
+            "`variables` must be a mapping {variable: ResamplingMethod}"
+        )
 
     if resampling_interval:
         validate_resampling_interval(resampling_interval)

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -59,7 +59,7 @@ def _get_variables_sequence_and_query_parameter_list(
         validate_resampling_interval(resampling_interval)
         variables_sequence = []
         variables_query_parameter_list = []
-        for variable, resampling_method in variables.items():
+        for variable, resampling_method in variables.items():  # type: ignore
             variables_sequence.append(variable)
             variables_query_parameter_list.append(
                 f"{variable.uuid}"
@@ -72,7 +72,7 @@ def _get_variables_sequence_and_query_parameter_list(
             )
         return variables_sequence, variables_query_parameter_list
 
-    return variables, [str(v.uuid) for v in variables]
+    return variables, [str(v.uuid) for v in variables]  # type: ignore
 
 
 class EnlyzeClient:
@@ -254,9 +254,12 @@ class EnlyzeClient:
         if not timeseries_data_chunked or None in timeseries_data_chunked:
             return None
 
-        timeseries_data = reduce(lambda x, y: x.merge(y), timeseries_data_chunked)
+        try:
+            timeseries_data = reduce(lambda x, y: x.merge(y), timeseries_data_chunked)  # type: ignore # noqa
+        except ValueError as e:
+            raise EnlyzeError from e
 
-        return timeseries_data.to_user_model(
+        return timeseries_data.to_user_model(  # type: ignore
             start=start,
             end=end,
             variables=variables_sequence,

--- a/src/enlyze/client.py
+++ b/src/enlyze/client.py
@@ -14,7 +14,7 @@ from enlyze.constants import (
     MAXIMUM_NUMBER_OF_VARIABLES_PER_TIMESERIES_REQUEST,
     VARIABLE_UUID_AND_RESAMPLING_METHOD_SEPARATOR,
 )
-from enlyze.errors import EnlyzeError
+from enlyze.errors import EnlyzeError, ResamplingValidationError
 from enlyze.iterable_tools import chunk
 from enlyze.validators import (
     validate_datetime,
@@ -55,7 +55,7 @@ def _get_variables_sequence_and_query_parameter_list(
     resampling_interval: Optional[int],
 ) -> Tuple[Sequence[user_models.Variable], Sequence[str]]:
     if isinstance(variables, abc.Sequence) and resampling_interval is not None:
-        raise EnlyzeError("`variables` must be a mapping {variable: ResamplingMethod}")
+        raise ResamplingValidationError("`variables` must be a mapping {variable: ResamplingMethod}")
 
     if resampling_interval:
         validate_resampling_interval(resampling_interval)

--- a/src/enlyze/constants.py
+++ b/src/enlyze/constants.py
@@ -18,3 +18,7 @@ VARIABLE_UUID_AND_RESAMPLING_METHOD_SEPARATOR = "||"
 
 #: The minimum allowed resampling interval when resampling timeseries data.
 MINIMUM_RESAMPLING_INTERVAL = 10
+
+#: The maximum number of variables that can be used in a single request when querying
+#: timeseries data.
+MAXIMUM_NUMBER_OF_VARIABLES_PER_TIMESERIES_REQUEST = 100

--- a/src/enlyze/constants.py
+++ b/src/enlyze/constants.py
@@ -9,7 +9,7 @@ PRODUCTION_RUNS_API_SUB_PATH = "api/production-runs/v1/"
 
 #: HTTP timeout for requests to the Timeseries API.
 #:
-#: Reference: https://www.python-httpx.org/advanced/#timeout-configuration
+#: Reference: https://www.python-httpx.org/advanced/timeouts/
 HTTPX_TIMEOUT = 30.0
 
 #: The separator to use when to separate the variable UUID and the resampling method

--- a/src/enlyze/iterable_tools.py
+++ b/src/enlyze/iterable_tools.py
@@ -1,0 +1,12 @@
+from typing import Iterable, Sequence, TypeVar
+
+MINIMUM_CHUNK_SIZE = 1
+
+T = TypeVar("T")
+
+
+def chunk(seq: Sequence[T], chunk_size: int) -> Iterable[Sequence[T]]:
+    if chunk_size < MINIMUM_CHUNK_SIZE:
+        raise ValueError(f"{chunk_size=} is less than {MINIMUM_CHUNK_SIZE=}")
+
+    return (seq[i : i + chunk_size] for i in range(0, len(seq), chunk_size))

--- a/tests/enlyze/api_clients/timeseries/test_models.py
+++ b/tests/enlyze/api_clients/timeseries/test_models.py
@@ -63,7 +63,7 @@ class TestTimeseriesData:
         )
 
         for r in merged.records:
-            assert len(r) == expected_merged_record_len
+            assert len(r) == expected_merged_record_len == len(merged.columns)
 
     def test_merge_raises_number_of_records_mismatch(
         self, timeseries_data_1, timeseries_data_2

--- a/tests/enlyze/api_clients/timeseries/test_models.py
+++ b/tests/enlyze/api_clients/timeseries/test_models.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from enlyze.api_clients.timeseries.models import TimeseriesData
+
+# We use this to skip  columns that contain the timestamp assuming
+# it starts at the beginning of the sequence. We also use it
+# when computing lengths to account for a timestamp column.
+TIMESTAMP_OFFSET = 1
+
+
+@pytest.fixture
+def timestamp():
+    return datetime.now(tz=timezone.utc)
+
+
+@pytest.fixture
+def timeseries_data_1(timestamp):
+    return TimeseriesData(
+        columns=["time", "var1", "var2"],
+        records=[
+            [timestamp.isoformat(), 1, 2],
+            [(timestamp - timedelta(minutes=10)).isoformat(), 3, 4],
+        ],
+    )
+
+
+@pytest.fixture
+def timeseries_data_2(timestamp):
+    return TimeseriesData(
+        columns=["time", "var3"],
+        records=[
+            [timestamp.isoformat(), 5],
+            [(timestamp - timedelta(minutes=10)).isoformat(), 6],
+        ],
+    )
+
+
+class TestTimeseriesData:
+    def test_merge(self, timeseries_data_1, timeseries_data_2):
+        timeseries_data_1_records_len = len(timeseries_data_1.records)
+        timeseries_data_1_columns_len = len(timeseries_data_1.columns)
+        timeseries_data_2_records_len = len(timeseries_data_2.records)
+        timeseries_data_2_columns_len = len(timeseries_data_2.columns)
+        expected_merged_record_len = len(timeseries_data_1.records[0]) + len(
+            timeseries_data_2.records[0][TIMESTAMP_OFFSET:]
+        )
+
+        merged = timeseries_data_1.merge(timeseries_data_2)
+
+        assert merged is timeseries_data_1
+        assert (
+            len(merged.records)
+            == timeseries_data_1_records_len
+            == timeseries_data_2_records_len
+        )
+        assert (
+            len(merged.columns)
+            == timeseries_data_1_columns_len
+            + timeseries_data_2_columns_len
+            - TIMESTAMP_OFFSET
+        )
+
+        for r in merged.records:
+            assert len(r) == expected_merged_record_len
+
+    def test_merge_raises_number_of_records_mismatch(
+        self, timeseries_data_1, timeseries_data_2
+    ):
+        timeseries_data_2.records = timeseries_data_2.records[1:]
+        with pytest.raises(
+            ValueError, match="Number of records in both instances has to be the same"
+        ):
+            timeseries_data_1.merge(timeseries_data_2)
+
+    def test_merge_raises_mismatched_timestamps(
+        self, timeseries_data_1, timeseries_data_2, timestamp
+    ):
+        timeseries_data_2.records[0][0] = (timestamp - timedelta(days=1)).isoformat()
+
+        with pytest.raises(ValueError, match="mismatched timestamps"):
+            timeseries_data_1.merge(timeseries_data_2)

--- a/tests/enlyze/test_client.py
+++ b/tests/enlyze/test_client.py
@@ -26,7 +26,7 @@ from enlyze.constants import (
     PRODUCTION_RUNS_API_SUB_PATH,
     TIMESERIES_API_SUB_PATH,
 )
-from enlyze.errors import EnlyzeError
+from enlyze.errors import EnlyzeError, ResamplingValidationError
 from tests.conftest import (
     datetime_before_today_strategy,
     datetime_today_until_now_strategy,
@@ -403,9 +403,8 @@ def test__get_timeseries_raises_variables_without_resampling_method(
     resampling methods.
     """
     client = make_client()
-    with pytest.raises(EnlyzeError) as exc_info:
+    with pytest.raises(ResamplingValidationError):
         client._get_timeseries(start_datetime, end_datetime, [variable], 30)
-    assert isinstance(exc_info.value.__cause__, ValueError)
 
 
 @given(

--- a/tests/enlyze/test_client.py
+++ b/tests/enlyze/test_client.py
@@ -62,7 +62,7 @@ production_runs_strategy = st.lists(
         uuid=st.uuids(),
         start=datetime_before_today_strategy,
         end=datetime_today_until_now_strategy,
-        machine=st.builds(
+        appliance=st.builds(
             production_runs_api_models.Machine, uuid=st.just(MACHINE_UUID)
         ),
         product=st.builds(

--- a/tests/enlyze/test_iterable_tools.py
+++ b/tests/enlyze/test_iterable_tools.py
@@ -1,0 +1,26 @@
+from typing import Sequence
+
+import pytest
+from hypothesis import given
+from hypothesis.strategies import integers, lists
+
+from enlyze.iterable_tools import MINIMUM_CHUNK_SIZE, chunk
+
+
+@given(
+    seq=lists(integers()),
+    chunk_size=integers(min_value=MINIMUM_CHUNK_SIZE),
+)
+def test_chunk(seq: Sequence[int], chunk_size: int):
+    result = list(chunk(seq, chunk_size))
+    assert sum(len(sublist) for sublist in result) == len(seq)
+    assert all(len(sublist) <= chunk_size for sublist in result)
+
+
+@given(
+    seq=lists(integers()),
+    chunk_size=integers(max_value=MINIMUM_CHUNK_SIZE - 1),
+)
+def test_chunk_raises_invalid_chunk_size(seq: Sequence[int], chunk_size: int):
+    with pytest.raises(ValueError):
+        chunk(seq, chunk_size)


### PR DESCRIPTION
closes https://github.com/enlyze/enlyze-python/issues/7

This PR fixes an issue where the user was allowed to request timeseries data for any number of variables but it'd fail because the `timeseries` API accepts a maximum of `100` variables per request. We now chunk the variables requested into chunks of size `<=100` and issue a request for each chunk and then merge the data returned in all of the responses.

This PR also refactors the logic to fetch timeseries data so that it has less repetition. Previously, there was a lot of overlap in the code in the `get_timeseries` and `get_timeseries_with_resampling` methods.