### PR TITLE
Fix ProductionRun API schema after renaming Appliance to Machine.

### DIFF
--- a/src/enlyze/api_clients/production_runs/models.py
+++ b/src/enlyze/api_clients/production_runs/models.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from typing import Any, Optional
 from uuid import UUID
 
+from pydantic import Field
+
 import enlyze.models as user_models
 from enlyze.api_clients.base import ApiBaseModel
 
@@ -66,7 +68,7 @@ class Machine(ApiBaseModel):
 
 class ProductionRun(ProductionRunsApiModel):
     uuid: UUID
-    machine: Machine
+    machine: Machine = Field(alias="appliance")
     average_throughput: Optional[float]
     production_order: str
     product: Product

--- a/tests/enlyze/test_client.py
+++ b/tests/enlyze/test_client.py
@@ -61,7 +61,7 @@ production_runs_strategy = st.lists(
         uuid=st.uuids(),
         start=datetime_before_today_strategy,
         end=datetime_today_until_now_strategy,
-        machine=st.builds(
+        appliance=st.builds(
             production_runs_api_models.Machine, uuid=st.just(APPLIANCE_UUID)
         ),
         product=st.builds(
@@ -435,7 +435,7 @@ def test_get_production_runs(
         )
         production_runs_api_mock.get("production-runs").mock(
             PaginatedProductionRunsApiResponse(
-                data=[p.model_dump() for p in production_runs]
+                data=[p.model_dump(by_alias=True) for p in production_runs]
             )
         )
 


### PR DESCRIPTION
This fixes a regression introduced by #37. Closes #41.