### PR TITLE
Use a custom user agent when issuing HTTP requests.

### DIFF
--- a/src/enlyze/api_clients/base.py
+++ b/src/enlyze/api_clients/base.py
@@ -8,9 +8,19 @@ from typing import Any, Generic, TypeVar
 import httpx
 from pydantic import BaseModel, ValidationError
 
+from enlyze._version import VERSION
 from enlyze.auth import TokenAuth
-from enlyze.constants import HTTPX_TIMEOUT
+from enlyze.constants import HTTPX_TIMEOUT, USER_AGENT
 from enlyze.errors import EnlyzeError, InvalidTokenError
+
+USER_AGENT_NAME_VERSION_SEPARATOR = "/"
+
+
+@cache
+def _construct_user_agent(
+    *, user_agent: str = USER_AGENT, version: str = VERSION
+) -> str:
+    return f"{user_agent}{USER_AGENT_NAME_VERSION_SEPARATOR}{version}"
 
 
 class ApiBaseModel(BaseModel):
@@ -60,6 +70,7 @@ class ApiBaseClient(ABC, Generic[R]):
             auth=TokenAuth(token),
             base_url=httpx.URL(base_url),
             timeout=timeout,
+            headers={"user-agent": _construct_user_agent()},
         )
 
     @cache

--- a/src/enlyze/constants.py
+++ b/src/enlyze/constants.py
@@ -22,3 +22,6 @@ MINIMUM_RESAMPLING_INTERVAL = 10
 #: The maximum number of variables that can be used in a single request when querying
 #: timeseries data.
 MAXIMUM_NUMBER_OF_VARIABLES_PER_TIMESERIES_REQUEST = 100
+
+#: The user agent that the SDK identifies itself as when making HTTP requests
+USER_AGENT = "enlyze-python"


### PR DESCRIPTION
# Description

This PR introduces adds a `User-Agent` header to `HTTP` requests made from the API clients, this will allow us to identify which requests originate from the SDK.

The `User-Agent` follows the format defined [here](https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agent).

This PR doesn't have `GDPR` implications as there's no personal data used and the user agent cannot be used to identify a specific user or clusters of users.

# References

- https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agent
- https://www.python-httpx.org/advanced/clients/#sharing-configuration-across-requests
- https://www.python-httpx.org/advanced/clients/#merging-of-configuration