### PR TITLE
Drop extra records when merging different `TimeseriesData` instances.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,12 @@ requires = [
   "setuptools",
 ]
 
-[tool.setuptools.dynamic]
-version = {attr = "enlyze._version.VERSION"}
-
 [project]
 name = "enlyze"
 description = "Python SDK for interacting with the ENLYZE platform https://www.enlyze.com"
 readme = "README.rst"
-license = {text = "MIT"}
-authors = [{name = "ENLYZE GmbH", email = "hello@enlyze.com"},]
+license = { text = "MIT" }
+authors = [ { name = "ENLYZE GmbH", email = "hello@enlyze.com" } ]
 requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
@@ -21,21 +18,20 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dynamic = [
-  'version',
+  "version",
 ]
 dependencies = [
   "httpx",
   "pandas>=2",
   "pydantic>=2",
 ]
-[project.optional-dependencies]
-docs = [
+optional-dependencies.docs = [
   "sphinx",
   "sphinx-rtd-theme",
   "sphinx-tabs",
   "sphinxcontrib-spelling",
 ]
-lint = [
+optional-dependencies.lint = [
   "bandit",
   "black",
   "flake8",
@@ -45,7 +41,7 @@ lint = [
   "safety",
   "tox-ini-fmt",
 ]
-test = [
+optional-dependencies.test = [
   "coverage",
   "hypothesis",
   "pandas-stubs",
@@ -57,8 +53,11 @@ test = [
   "respx",
 ]
 
-[tool.mypy]
-exclude="tests"
+[tool.setuptools.dynamic]
+version = { attr = "enlyze._version.VERSION" }
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+exclude = "tests"

--- a/src/enlyze/api_clients/timeseries/models.py
+++ b/src/enlyze/api_clients/timeseries/models.py
@@ -77,16 +77,19 @@ class TimeseriesData(TimeseriesApiModel):
 
     def merge(self, other: "TimeseriesData") -> "TimeseriesData":
         """Merge records from ``other`` into the existing records."""
-        if not (slen := len(self.records)) == (olen := len(other.records)):
+        slen, olen = len(self.records), len(other.records)
+        if olen < slen:
             raise ValueError(
-                "Cannot merge. Number of records in both instances has to be the same,"
-                f" trying to merge an instance with {olen} records into an instance"
-                f" with {slen} records."
+                "Cannot merge. Attempted to merge"
+                f" an instance with {olen} records into an instance with {slen}"
+                " records. The instance to merge must have a number"
+                " of records greater than or equal to the number of records of"
+                " the instance you're trying to merge into."
             )
 
         self.columns.extend(other.columns[1:])
 
-        for s, o in zip(self.records, other.records):
+        for s, o in zip(self.records, other.records[:slen]):
             if s[0] != o[0]:
                 raise ValueError(
                     "Cannot merge. Attempted to merge records "

--- a/tests/enlyze/api_clients/timeseries/test_models.py
+++ b/tests/enlyze/api_clients/timeseries/test_models.py
@@ -37,40 +37,60 @@ def timeseries_data_2(timestamp):
     )
 
 
+@pytest.fixture
+def timeseries_data_3(timestamp):
+    return TimeseriesData(
+        columns=["time", "var3"],
+        records=[
+            [timestamp.isoformat(), 5],
+            [(timestamp - timedelta(minutes=10)).isoformat(), 6],
+            [(timestamp - timedelta(minutes=10)).isoformat(), 7],
+            [(timestamp - timedelta(minutes=10)).isoformat(), 8],
+        ],
+    )
+
+
 class TestTimeseriesData:
-    def test_merge(self, timeseries_data_1, timeseries_data_2):
-        timeseries_data_1_records_len = len(timeseries_data_1.records)
-        timeseries_data_1_columns_len = len(timeseries_data_1.columns)
-        timeseries_data_2_records_len = len(timeseries_data_2.records)
-        timeseries_data_2_columns_len = len(timeseries_data_2.columns)
-        expected_merged_record_len = len(timeseries_data_1.records[0]) + len(
-            timeseries_data_2.records[0][TIMESTAMP_OFFSET:]
+    @pytest.mark.parametrize(
+        "data_fixture,data_to_merge_fixture",
+        [
+            ("timeseries_data_1", "timeseries_data_2"),
+            ("timeseries_data_1", "timeseries_data_3"),
+        ],
+    )
+    def test_merge(self, request, data_fixture, data_to_merge_fixture):
+        data = request.getfixturevalue(data_fixture)
+        data_to_merge = request.getfixturevalue(data_to_merge_fixture)
+        data_records_len = len(data.records)
+        data_columns_len = len(data.columns)
+        data_to_merge_columns_len = len(data_to_merge.columns)
+        expected_merged_record_len = len(data.records[0]) + len(
+            data_to_merge.records[0][TIMESTAMP_OFFSET:]
         )
 
-        merged = timeseries_data_1.merge(timeseries_data_2)
+        merged = data.merge(data_to_merge)
 
-        assert merged is timeseries_data_1
-        assert (
-            len(merged.records)
-            == timeseries_data_1_records_len
-            == timeseries_data_2_records_len
-        )
+        assert merged is data
+        assert len(merged.records) == data_records_len
         assert (
             len(merged.columns)
-            == timeseries_data_1_columns_len
-            + timeseries_data_2_columns_len
-            - TIMESTAMP_OFFSET
+            == data_columns_len + data_to_merge_columns_len - TIMESTAMP_OFFSET
         )
 
         for r in merged.records:
             assert len(r) == expected_merged_record_len == len(merged.columns)
 
-    def test_merge_raises_number_of_records_mismatch(
+    def test_merge_raises_number_of_records_to_merge_less_than_existing(
         self, timeseries_data_1, timeseries_data_2
     ):
         timeseries_data_2.records = timeseries_data_2.records[1:]
         with pytest.raises(
-            ValueError, match="Number of records in both instances has to be the same"
+            ValueError,
+            match=(
+                "The instance to merge must have a number of"
+                " records greater than or equal to the number"
+                " of records of the instance you're trying to merge into."
+            ),
         ):
             timeseries_data_1.merge(timeseries_data_2)
 


### PR DESCRIPTION
This PR handles the situation when attempting to merge timeseries records of different chunks where a later chunk has extra records.