### PR TITLE
Fix incompatibility with `httpx>=0.28`

### DIFF
--- a/src/enlyze/api_clients/production_runs/client.py
+++ b/src/enlyze/api_clients/production_runs/client.py
@@ -46,10 +46,10 @@ class ProductionRunsApiClient(ApiBaseClient[_PaginatedResponse]):
 
     def _next_page_call_args(
         self,
-        url: str,
+        url: str | httpx.URL,
         params: dict[str, Any],
         paginated_response: _PaginatedResponse,
         **kwargs: Any,
-    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    ) -> tuple[str | httpx.URL, dict[str, Any], dict[str, Any]]:
         next_params = {**params, "cursor": paginated_response.metadata.next_cursor}
         return (url, next_params, kwargs)

--- a/src/enlyze/api_clients/timeseries/client.py
+++ b/src/enlyze/api_clients/timeseries/client.py
@@ -54,10 +54,10 @@ class TimeseriesApiClient(ApiBaseClient[_PaginatedResponse]):
     def _next_page_call_args(
         self,
         *,
-        url: str,
+        url: str | httpx.URL,
         params: dict[str, Any],
         paginated_response: _PaginatedResponse,
         **kwargs: Any,
-    ) -> Tuple[str, dict[str, Any], dict[str, Any]]:
+    ) -> Tuple[str | httpx.URL, dict[str, Any], dict[str, Any]]:
         next_url = str(paginated_response.next)
         return (next_url, params, kwargs)


### PR DESCRIPTION
In `httpx==0.28.0`, the handling of GET query parameters has changed in a backwards-incompatible way. The new behaviour is to replace query parameters in the URL when parameters are passed via the `params` kwarg. Our pagination code expects that parameters in the URL get merged with the additional parameters of the `params` kwarg. This PR explicitly implements the old behaviour of merging params to fix compatibility with recent releases of `httpx`.

refs: 
- https://github.com/encode/httpx/pull/3364
- https://github.com/encode/httpx/pull/3440