### PR TITLE
Update quickstart auth docs for self-serve API keys

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,10 @@ nitpick_ignore_regex = [
 ]
 nitpick_ignore = [
     ("py:class", "ComputedFieldInfo"),
+    # Sphinx autodoc fully-qualifies the pandas.DataFrame return annotation to
+    # pandas.core.frame.DataFrame, which pandas does not publish in its
+    # intersphinx inventory (only the public pandas.DataFrame is documented).
+    ("py:class", "pandas.core.frame.DataFrame"),
 ]
 
 autodoc_default_options = {"exclude-members": "__weakref__, __init__, __new__"}

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ create and manage API keys yourself directly within the ENLYZE platform. See
 `Creating and Managing API Keys <https://docs.enlyze.com/en/administration/api-keys>`_
 for step-by-step instructions on how to retrieve one.
 
-Every API key grants full read access to all the data of your organization, so please
+Every API key grants full access to all the data of your organization, so please
 keep it safe and treat it like a password! API keys are only displayed once at creation
 time and cannot be recovered. If you have lost your key or think it might have been
 compromised, simply revoke it and create a new one.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,22 +6,26 @@ Make sure you have the ``enlyze`` SDK Python package :doc:`installed </installat
 Authentication
 --------------
 
-In order to interact with the ENLYZE platform you need to acquire an API token. If you
-haven't received one already, please reach out to us at hello@enlyze.com. This token
-will give you access to all the data of your organization, so please keep it safe! In
-case you have lost your token or you think it might have been compromised please reach
-out to us as well.
+In order to interact with the ENLYZE platform you need to acquire an API key. You can
+create and manage API keys yourself directly within the ENLYZE platform. See
+`Creating and Managing API Keys <https://docs.enlyze.com/en/administration/api-keys>`_
+for step-by-step instructions on how to retrieve one.
+
+Every API key grants full read access to all the data of your organization, so please
+keep it safe and treat it like a password! API keys are only displayed once at creation
+time and cannot be recovered. If you have lost your key or think it might have been
+compromised, simply revoke it and create a new one.
 
 Client setup
 ------------
 
 The ``EnlyzeClient`` class is your main entrypoint to interact with the ENLYZE platform.
-It takes care of authentication so you must pass your access token to it.
+It takes care of authentication so you must pass your API key to it.
 
 .. code-block:: pycon
 
     >>> from enlyze import EnlyzeClient
-    >>> enlyze = EnlyzeClient('my_api_token')
+    >>> enlyze = EnlyzeClient('my_api_key')
 
 Exploration
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
   "version",
@@ -53,8 +54,8 @@ optional-dependencies.test = [
   "respx",
 ]
 
-[tool.setuptools.dynamic]
-version = { attr = "enlyze._version.VERSION" }
+[tool.setuptools]
+dynamic.version = { attr = "enlyze._version.VERSION" }
 
 [tool.isort]
 profile = "black"

--- a/src/enlyze/models.py
+++ b/src/enlyze/models.py
@@ -332,7 +332,7 @@ class ProductionRuns(list[ProductionRun]):
         path_separator = "."
 
         df = pandas.json_normalize([asdict(run) for run in self], sep=path_separator)
-        df.start = pandas.to_datetime(df.start, utc=True, format="ISO8601")
-        df.end = pandas.to_datetime(df.end, utc=True, format="ISO8601")
+        df["start"] = pandas.to_datetime(df["start"], utc=True, format="ISO8601")
+        df["end"] = pandas.to_datetime(df["end"], utc=True, format="ISO8601")
 
         return dataframe_ensure_schema(df, ProductionRun, path_separator=path_separator)

--- a/tests/enlyze/api_client/test_client.py
+++ b/tests/enlyze/api_client/test_client.py
@@ -284,7 +284,7 @@ def test_get_paginated_multi_page(
 @respx.mock
 def test_get_paginated_raises_on_invalid_data(api_client):
     class TestModel(PlatformApiModel):
-        my_field: int  # type:ignore
+        my_field: int  # type: ignore
 
     invalid_data = [{"invalid": "data"}]
     paginated_response = _PaginatedResponse(

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
 skip_install = true
 deps =
     pyproject-fmt
+    tomli; python_version < "3.11"
 commands =
     pyproject-fmt pyproject.toml
 


### PR DESCRIPTION
## What

Updates the Authentication section of the quickstart docs to reflect that API keys can now be created and managed self-serve within the ENLYZE platform.

- Replaces the "reach out to us at hello@enlyze.com" flow with a link to the [Creating and Managing API Keys](https://docs.enlyze.com/en/administration/api-keys) documentation.
- Aligns terminology from "access token" to "API key" throughout (including the client setup example).
- Keeps the safety guidance and updates the lost/compromised note to reflect that keys are now self-revocable.